### PR TITLE
Calculates move time instead of the total time elapsed

### DIFF
--- a/src/Services/GpxParser.php
+++ b/src/Services/GpxParser.php
@@ -3,8 +3,6 @@
 namespace App\Services;
 
 use App\Models\GpxStats;
-use Carbon\Carbon;
-use Carbon\CarbonInterface;
 use DateTime;
 use phpGPX\Models\Point;
 use phpGPX\phpGPX;


### PR DESCRIPTION
This one might be kind of opinionated but I think showing moving time instead of total time elapsed between start/stop would make more sense.

This is the activity as an example (where a good chunk of the time was spent idle)
https://www.strava.com/activities/7901660490

![](https://i.ritvars.lv/screen_2022-10-04_20-53-14_riaK.png)

![](https://i.ritvars.lv/screen_2022-10-04_20-49-54_YBYz.png)

Although these changes make the time spent more accurate, the time is still off by a couple of minutes from the Strava calculated one. While I tested this with a couple of different GPX files (walking/running), this probably needs bit more extensive testing. 

Comments / changes welcome.

